### PR TITLE
run old-style flows for <=0.7 only

### DIFF
--- a/tests/testthat/test-bijectors.R
+++ b/tests/testthat/test-bijectors.R
@@ -30,6 +30,7 @@ test_succeeds("Use tfb_masked_autoregressive_default_template", {
 
 test_succeeds("Use masked autoregressive flow with template", {
   skip_if_not_eager()
+  skip_if_tfp_above("0.7")
   dims <- 5L
   maf <- tfd_transformed_distribution(
     distribution = tfd_normal(loc = 0, scale = 1),
@@ -42,15 +43,13 @@ test_succeeds("Use masked autoregressive flow with template", {
   loss <- function()
     - tf$reduce_mean(maf %>% tfd_log_prob(y))
   optimizer <- tf$optimizers$Adam(1e-4)
-
-  # put back in when solved!
-  # TypeError: minimize() missing 1 required positional argument: 'var_list'
-  # optimizer$minimize(loss)
-  # x <- maf %>% tfd_sample() %>% tensor_value()
+  optimizer$minimize(loss)
+  x <- maf %>% tfd_sample() %>% tensor_value()
 })
 
 test_succeeds("Use a tfb_inverse autoregressive flow", {
   skip_if_not_eager()
+  skip_if_tfp_above("0.7")
   dims <- 5L
   iaf <- tfd_transformed_distribution(
     distribution = tfd_normal(loc = 0, scale = 1),
@@ -66,15 +65,14 @@ test_succeeds("Use a tfb_inverse autoregressive flow", {
     - tf$reduce_mean(iaf %>% log_prob(y))
   }
 
-  # put back in when solved!
-  # TypeError: minimize() missing 1 required positional argument: 'var_list'
-  # optimizer <- tf$optimizers$Adam(1e-4)
-  # optimizer$minimize(loss)
+  optimizer <- tf$optimizers$Adam(1e-4)
+  optimizer$minimize(loss)
   x <- iaf %>% tfd_sample() %>% tensor_value()
 })
 
 test_succeeds("Use real NVP with template", {
   skip_if_not_eager()
+  skip_if_tfp_above("0.7")
   dims <- 5L
   rnvp <- tfd_transformed_distribution(
     distribution = tfd_normal(loc = 0, scale = 1),
@@ -90,11 +88,8 @@ test_succeeds("Use real NVP with template", {
   loss <- function()
     - tf$reduce_mean(rnvp %>% log_prob(y))
   optimizer <- tf$optimizers$Adam(1e-4)
-
-  # put back in when solved!
-  # TypeError: minimize() missing 1 required positional argument: 'var_list'
-  # optimizer$minimize(loss)
-  # x <- rnvp %>% sample() %>% tensor_value()
+  optimizer$minimize(loss)
+  x <- rnvp %>% sample() %>% tensor_value()
 })
 
 # Bijectors ---------------------------------------------------------------


### PR DESCRIPTION
as per discussions on the TFP mailing list:

> - We recommend using `tfb.AutoregressiveNetwork` over `tfb.masked_autoregressive_default_template`.  AutoregressiveNetwork is an updated version designed to work with TF 2.0 and Keras.

 > - There is an example of training a MaskedAutoregressiveFlow bijector with an AutoregressiveNetwork (using the Keras Functional API) in the docstring for the AutoregressiveNetwork class at https://github.com/tensorflow/probability/blob/56a11e4152dd5ac7d67e8cdefbbfb2001c89e11a/tensorflow_probability/python/bijectors/masked_autoregressive.py#L593 .

